### PR TITLE
Clarify example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ resources:
 ### Examples
 
 ```yaml
-- type: 'custom:sun-card'
-  name: Sun
-  meridiem: false
-  entities:
-    max_elevation: sun.sun
-    sunrise: sensor.sunrise
-    sunset: sensor.sunset
-    noon: sensor.solar_noon
-    moon_phase: sensor.moon
+type: 'custom:sun-card'
+name: Sun
+meridiem: false
+entities:
+  max_elevation: sun.sun
+  sunrise: sensor.sunrise
+  sunset: sensor.sunset
+  noon: sensor.solar_noon
+  moon_phase: sensor.moon
 ```
 
 <img src="https://raw.githubusercontent.com/mishaaq/sun-card/master/images/showcase.png" width="450px"/>


### PR DESCRIPTION
```
- type: custom:...
```
defines a *list* of cards. That's confusing to users.
Better to show the configuration for a single card.